### PR TITLE
Remove usage of deprecated `to_graphql`

### DIFF
--- a/graphql-decorate.gemspec
+++ b/graphql-decorate.gemspec
@@ -4,15 +4,16 @@ lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'graphql/decorate/version'
 
+# rubocop:disable Metrics/BlockLength
 Gem::Specification.new do |spec|
-  spec.name          = 'graphql-decorate'
-  spec.version       = GraphQL::Decorate::VERSION
-  spec.authors       = ['Ben Brook']
-  spec.email         = ['bbrook154@gmail.com']
+  spec.name = 'graphql-decorate'
+  spec.version = GraphQL::Decorate::VERSION
+  spec.authors = ['Ben Brook']
+  spec.email = ['bbrook154@gmail.com']
 
-  spec.summary       = 'A decorator integration for the GraphQL gem'
-  spec.homepage      = 'https://www.github.com/TrueCar/graphql-decorate'
-  spec.license       = 'MIT'
+  spec.summary = 'A decorator integration for the GraphQL gem'
+  spec.homepage = 'https://www.github.com/TrueCar/graphql-decorate'
+  spec.license = 'MIT'
   spec.metadata = {
     'rubygems_mfa_required' => 'true'
   }
@@ -20,7 +21,7 @@ Gem::Specification.new do |spec|
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added
   # into git.
-  spec.files         = Dir.chdir(File.expand_path(__dir__)) do
+  spec.files = Dir.chdir(File.expand_path(__dir__)) do
     `git ls-files -z`.split("\x0").reject do |f|
       f.match(%r{^(test|spec|features)/})
     end
@@ -41,3 +42,4 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'simplecov', '~> 0.21.2'
   spec.add_development_dependency 'yard', '~> 0.9.26'
 end
+# rubocop:enable Metrics/BlockLength

--- a/graphql-decorate.gemspec
+++ b/graphql-decorate.gemspec
@@ -13,6 +13,9 @@ Gem::Specification.new do |spec|
   spec.summary       = 'A decorator integration for the GraphQL gem'
   spec.homepage      = 'https://www.github.com/TrueCar/graphql-decorate'
   spec.license       = 'MIT'
+  spec.metadata = {
+    'rubygems_mfa_required' => 'true'
+  }
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added

--- a/lib/graphql/decorate.rb
+++ b/lib/graphql/decorate.rb
@@ -35,7 +35,7 @@ module GraphQL
     # @param schema_defn [GraphQL::Schema] Current schema class
     # @return [nil]
     def self.use(schema_defn)
-      schema_defn.to_graphql.types.each do |_name, type|
+      schema_defn.types.each do |_name, type|
         next unless type.respond_to?(:fields)
 
         type.fields.each do |_name, field|


### PR DESCRIPTION
## What

Closes #19. As far as I can tell `GraphQL::Schema.types` now exposes the equivalent.