### PR TITLE
Remove unneeded type_class method to ensure graphql 2.0 compatibility

### DIFF
--- a/graphql-decorate.gemspec
+++ b/graphql-decorate.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.6.0'
 
-  spec.add_runtime_dependency 'graphql', '>= 1.3', '< 2'
+  spec.add_runtime_dependency 'graphql', '>= 1.3'
 
   spec.add_development_dependency 'bundler', '>= 2'
   spec.add_development_dependency 'rake', '>= 12.3.3'

--- a/lib/graphql/decorate.rb
+++ b/lib/graphql/decorate.rb
@@ -39,9 +39,9 @@ module GraphQL
         next unless type.respond_to?(:fields)
 
         type.fields.each do |_name, field|
-          field_type = extract_type(field.type_class.type)
+          field_type = extract_type(field.type)
           type_attributes = GraphQL::Decorate::TypeAttributes.new(field_type)
-          field.type_class.extension(GraphQL::Decorate::FieldExtension) if type_attributes.decoratable?
+          field.extension(GraphQL::Decorate::FieldExtension) if type_attributes.decoratable?
         end
       end
     end

--- a/lib/graphql/decorate/version.rb
+++ b/lib/graphql/decorate/version.rb
@@ -3,6 +3,6 @@
 module GraphQL
   module Decorate
     # Current version number
-    VERSION = '1.0.2'
+    VERSION = '1.0.3'
   end
 end


### PR DESCRIPTION
Fixes #22. The `type_class` method doesn't seem to be necessary and should behave identically to `field`.