### PR TITLE
Fix GQL 2.0 Schema Resolve Bug

### DIFF
--- a/lib/graphql/decorate/undecorated_field.rb
+++ b/lib/graphql/decorate/undecorated_field.rb
@@ -105,9 +105,18 @@ module GraphQL
                                           GraphQL::Decorate::TypeAttributes.new(type.resolve_type(value,
                                                                                                   graphql_context))
                                         else
-                                          graphql_context.schema.resolve_type(type, value, graphql_context)
+                                          resolve_type_attributes_from_schema
                                         end
                                       end
+      end
+
+      def resolve_type_attributes_from_schema
+        result = graphql_context.schema.resolve_type(type, value, graphql_context)
+        return result unless result.is_a?(Array) && result.size == 2
+
+        result[0]
+          .authorized_new(result[1], graphql_context)
+          .then(&GraphQL::Decorate::TypeAttributes.method(:new))
       end
     end
   end

--- a/lib/graphql/decorate/version.rb
+++ b/lib/graphql/decorate/version.rb
@@ -3,6 +3,6 @@
 module GraphQL
   module Decorate
     # Current version number
-    VERSION = '1.0.3'
+    VERSION = '1.0.4'
   end
 end


### PR DESCRIPTION
After updating to the latest GQL 2.0 gem we've run into a bug
where dynamic field types such as Unions cannot be resolved
correctly.  This is because the `resolve_type` method on the
schema class returns a two element array / tuple where the first
element is the type and the second element is the value.

This code hooks into this possibility and correctly initializes
the object so that that the `GraphQL::Decorate::TypeAttributes`
can wrap it.